### PR TITLE
Reduce width of index page menu

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -14,7 +14,7 @@ const IndexPage = (props: PageProps) => {
     <main className={styles.main}>
       <section className={[styles.section, styles.sectionOne].join(' ')}>
         <header className={styles.landingHeader}>
-          <Link to="/" style={{ marginLeft: 0 }}><div className={styles.swiftIcon} /></Link>
+          <Link to="/" style={{ marginLeft: 0, height: "8vh", width: "8vh" }}><div className={styles.swiftIcon} /></Link>
           {/*<div className={styles.dropDown}>
             <Link to="/">Home</Link>
             <div className={styles.dropDownMenu}>

--- a/src/pages/styles/index.module.scss
+++ b/src/pages/styles/index.module.scss
@@ -22,6 +22,7 @@
 .landingHeader {
     display: flex;
     flex-direction: column;
+    width: fit-content;
     & a {
         text-decoration: none;
         color: black;


### PR DESCRIPTION
I noticed a minor issue with the website, where the menu links in the index page will occupy a large width. Hovering the cursor above them will make the link interactive, even when significantly far away from the text itself.

The commit here:
- changes the width of `.landingHeader` to `fit-content`, and
- tweaks the height and width of the icon's link element to fit the icon only.

Here's a quick table of what changed:

| Before | After |
|:------:|:------:|
|  ![SAP_Before](https://user-images.githubusercontent.com/47273556/129822579-22fa1af9-66ff-4954-9de7-f493d3429caa.jpg) |  ![SAP_After](https://user-images.githubusercontent.com/47273556/129822589-5e3ab8ad-715c-433a-ad28-6c7b2b9b05e7.jpg) |

If there's a better way to do this, please suggest!

Thank you! 🙌 

